### PR TITLE
change mailpw to mail_pw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,6 @@ Sends you messages at random intervals for testing.
 
 How to start:
 ```
-addr= mailpw= cargo run
+addr= mail_pw= cargo run
 ```
 (fill env vars with your data of course)

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,12 +147,12 @@ async fn main() -> anyhow::Result<()> {
         } else {
             panic!("no addr ENV var specified");
         }
-        if let Some(pw) = vars().find(|key| key.0 == "mailpw") {
+        if let Some(pw) = vars().find(|key| key.0 == "mail_pw") {
             ctx.set_config(config::Config::MailPw, Some(&pw.1))
                 .await
                 .context("set config failed")?;
         } else {
-            panic!("no mailpw ENV var specified");
+            panic!("no mail_pw ENV var specified");
         }
         ctx.set_config(config::Config::Bot, Some("1"))
             .await


### PR DESCRIPTION
In the core and pretty much any other bot this variable is called mail_pw instead of mailpw... this short PR should make this bot conform. Better fix it now before it gets deployed anywhere else ;)